### PR TITLE
RTDT-2025 Add possibility to setup last_modified_timeout for customers for rosbag uploader

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -112,3 +112,11 @@ Actions: Add the configuration to the defaults.yaml and if needed, to the attrib
 How to keep release versions?
 
 Same parameter is different levels? What's the hirearchy?
+
+
+## How to use for rosbags recorder and uploader
+
+- clone to /data: `cd /data; git clone https://github.com/logivations/amr_config general_config`
+- check out the branch specific to your site, to get the configuration
+- restart rosbag_recorder and rosbag_uploader in Monit container or inside container, e.g. by `monit restart -g rosbags`
+- **important**: Do not copy the whole config file. Instead, only add the properties you want to modify. This way, improvements to the default values will be automatically applied. If you copy the whole config, you will be stuck on old default values forever.

--- a/rosbags/rosbag_recorder.yaml
+++ b/rosbags/rosbag_recorder.yaml
@@ -1,0 +1,3 @@
+#/**:
+#  tracking_rosbag_recorder:
+#    ros__parameters:

--- a/rosbags/rosbag_uploader.yaml
+++ b/rosbags/rosbag_uploader.yaml
@@ -1,0 +1,3 @@
+#/**:
+#  tracking_rosbag_uploader:
+#    ros__parameters:


### PR DESCRIPTION
Related to: https://lvserv01.logivations.com/browse/RTDT-2025
Deep_cv pull request:  https://github.com/logivations/deep_cv/pull/8269

Updated "How to use" in Readme.md.
We will use this "genera_config" not related to AMRs. It is general configuration for yaml files.